### PR TITLE
Use timeout instead of signal to make the clock tick

### DIFF
--- a/clock.cxx
+++ b/clock.cxx
@@ -71,7 +71,6 @@
 #include "ldisplay.h"
 #include "lwindow.h"
 #include "lres.h"
-#include "signal.h"		// Our signal wrapper
 
 #include "buici.xbm"		// Our name as a bitmap
 
@@ -100,7 +99,6 @@ extern int g_fOverrideRedirect;
 extern int g_showSecondHand;
 
 int do_clock (void);
-void signal_alarm (LSignalHandle handle, void* pv);
 int x_after (Display*);
 time_t calc_delta (time_t);
 
@@ -806,22 +804,6 @@ void WTopLevel::render_line (GC gc, Pixmap pixmap, double theta,
 }
 
 
-void WTopLevel::setup_time (void)
-{
-				// -- Configure interval timer
-  LSignal::accept (SIGALRM, signal_alarm, (void*) this, 0, 0);
-  {
-    struct itimerval value;
-    memset (&value, 0, sizeof (value));
-    value.it_interval.tv_sec = 0;
-    value.it_interval.tv_usec = 100000;
-    value.it_value.tv_usec = 1;
-    //      value.it_value = value.it_interval;
-    setitimer (ITIMER_REAL, &value, NULL);
-  }
-}
-
-
 void WTopLevel::shape (void)
 {
   int i;
@@ -941,7 +923,6 @@ int do_clock (void)
 
     pWindow->allocate_colors ();		// First, create the colormap
 
-    pWindow->setup_time ();
     pWindow->render ();
     pWindow->map ();
 
@@ -950,7 +931,11 @@ int do_clock (void)
     //    fprintf (stderr, "starting dispatch\n");
 
     while (!g_fQuit) {
-      display.dispatch_next_event ();
+      display.dispatch_next_event_timeout (100000);
+      if (pWindow->render () || pWindow->is_expose ()) {
+        pWindow->draw ();
+        pWindow->display ()->flush ();
+      }
     }
 
     fprintf (stderr, "exiting\n");
@@ -963,15 +948,4 @@ int do_clock (void)
 //  dmalloc_exit ();		// See what is left allocated
 
   return 0;
-}
-
-void signal_alarm (LSignalHandle /* handle */, void* pv)
-{
-  //  fprintf (stderr, "tick\n");
-  WTopLevel* pWindow = (WTopLevel*) pv;
-  if (pWindow->render () || pWindow->is_expose ()) {
-    pWindow->draw ();
-    pWindow->display ()->flush ();
-  }
-  //  fprintf (stderr, "tock\n");
 }

--- a/xo/ldisplay.cxx
+++ b/xo/ldisplay.cxx
@@ -34,6 +34,9 @@
 #include "ldisplay.h"
 #include "lwindow.h"
 
+#include <sys/select.h>
+#include <sys/time.h>
+
 unsigned long LDisplay::color_distance (XColor& color, XColor& colorMatch)
 {
   unsigned long sh = 16 - m_pVisual->bits_per_rgb;
@@ -58,8 +61,14 @@ void LDisplay::dispatch (XEvent* pEvent)
 
 void LDisplay::dispatch_next_event (void)
 {
+  dispatch_next_event_timeout (-1);
+}
+
+void LDisplay::dispatch_next_event_timeout (long usec)
+{
   XEvent event;
-  next_event (&event);
+  if (!next_event_timeout (&event, usec))
+    return;
 
 				// Update keyboard mapping
   if (event.type == MappingKeyboard) {
@@ -83,6 +92,35 @@ LWindow* LDisplay::find_child (int id)
   return m_pWindowRoot ? m_pWindowRoot->find_sibling (id) : (LWindow*) NULL;
 }
 
+bool LDisplay::next_event_timeout (XEvent* pEvent, long usec)
+{
+  fd_set fds;
+  int r, fd;
+  struct timeval tv;
+
+  if (!m_pDisplay)
+    return false;
+
+  if (usec < 0 || XPending (m_pDisplay)) {
+    XNextEvent (m_pDisplay, pEvent);
+    return true;
+  }
+
+  fd = ConnectionNumber (m_pDisplay);
+  FD_ZERO (&fds);
+  FD_SET (fd, &fds);
+  tv.tv_sec = 0;
+  tv.tv_usec = usec;
+
+  r = select (fd + 1, &fds, NULL, NULL, &tv);
+
+  if (r > 0 && XPending (m_pDisplay)) {
+    XNextEvent (m_pDisplay, pEvent);
+    return true;
+  }
+
+  return false;
+}
 
 bool LDisplay::open (char* szDisplay)
 {

--- a/xo/ldisplay.h
+++ b/xo/ldisplay.h
@@ -111,6 +111,7 @@ public:
 
   unsigned long color_distance (XColor& color, XColor& colorMatch);
   void dispatch_next_event (void);
+  void dispatch_next_event_timeout (long usec);
   void dispatch (XEvent* pEvent);
   Colormap colormap (void) {
     return m_colormap; }
@@ -151,6 +152,7 @@ public:
   bool hash_template (const char* szTemplate, LWindow* pWindow);
   void next_event (XEvent* pEvent) {
     m_pDisplay ? XNextEvent (m_pDisplay, pEvent) : 0; }
+  bool next_event_timeout (XEvent* pEvent, long usec);
   bool open (char* szDisplay = NULL);
   void unhash_window (LWindow* pWindow);
 


### PR DESCRIPTION
Previous code called non-reentrant function from the signal handler. Remove the signal handler and replace it with a timeout when getting the next event.

Closes: https://github.com/rosorio/buici-clock/issues/2